### PR TITLE
Fix #17 - Add css only when shortcode used

### DIFF
--- a/oembed-gist.php
+++ b/oembed-gist.php
@@ -24,8 +24,6 @@ class gist {
 
 	public function plugins_loaded()
 	{
-		add_action( 'wp_head', array( $this, 'wp_head' ) );
-
 		load_plugin_textdomain(
 			'oembed-gist',
 			false,
@@ -76,7 +74,7 @@ class gist {
 		return $providers;
 	}
 
-	public function wp_head()
+	public function gist_css()
 	{
 		?>
 		<style>
@@ -145,6 +143,7 @@ class gist {
 		if( is_feed() ){
 			return $noscript;
 		}else{
+            add_action( 'wp_footer', array( $this, 'gist_css' ) );
 			return sprintf(
 				'<div class="oembed-gist"><script src="%s"></script><noscript>%s</noscript></div>',
 				$url,


### PR DESCRIPTION
Add the in-page CSS to the footer and only when the shortcode is used. Rename the function from 'wp_head' to 'gist_css' to reflect its new use.