### PR TITLE
Allow disabling of injection of CSS

### DIFF
--- a/oembed-gist.php
+++ b/oembed-gist.php
@@ -76,6 +76,8 @@ class gist {
 
 	public function gist_css()
 	{
+        $inject_css = true;
+        if ( apply_filters( 'oembed_gist_inject_css', $inject_css ) ) {
 		?>
 		<style>
 		.gist table {
@@ -105,6 +107,7 @@ class gist {
 		}
 		</style>
 		<?php
+        }
 	}
 
 	public function handler( $m, $attr, $url, $rattr )


### PR DESCRIPTION
To fix #18.
Use apply_filters() to allow disabling of injection of CSS in gist_css() (formerly wp_head function).

To disable the injection you can use:
add_filter( 'oembed_gist_inject_css', '__return_false');